### PR TITLE
Add `try/catch` clauses around a couple Object.*() functions

### DIFF
--- a/index.js
+++ b/index.js
@@ -311,8 +311,14 @@ function formatValue(ctx, value, recurseTimes) {
 function formatProperty(ctx, value, recurseTimes, visibleKeys, key, array) {
   var name, str, desc;
   desc = { value: value[key] };
-  if (Object.getOwnPropertyDescriptor) {
-    desc = Object.getOwnPropertyDescriptor(value, key) || desc;
+  try {
+    // ie10 › Object.getOwnPropertyDescriptor(window.location, 'hash')
+    // throws TypeError: Object doesn't support this action
+    if (Object.getOwnPropertyDescriptor) {
+      desc = Object.getOwnPropertyDescriptor(value, key) || desc;
+    }
+  } catch (e) {
+    // ignore
   }
   if (desc.get) {
     if (desc.set) {


### PR DESCRIPTION
These have a possibility of throwing an Error if given funky host objects in old IEs.
