### PR TITLE
index: default the property descriptor to an `undefined` value

### DIFF
--- a/index.js
+++ b/index.js
@@ -310,7 +310,14 @@ function formatValue(ctx, value, recurseTimes) {
 
 function formatProperty(ctx, value, recurseTimes, visibleKeys, key, array) {
   var name, str, desc;
-  desc = { value: value[key] };
+  desc = { value: void 0 };
+  try {
+    // ie6 › navigator.toString
+    // throws Error: Object doesn't support this property or method
+    desc.value = value[key];
+  } catch (e) {
+    // ignore
+  }
   try {
     // ie10 › Object.getOwnPropertyDescriptor(window.location, 'hash')
     // throws TypeError: Object doesn't support this action


### PR DESCRIPTION
In some older misbehaving browsers, simply getting the `value[key]`
would something throw an error. `navigator.toString` is a good example
in IE 6 and 7.
