### PR TITLE
Add UMD support for use via npmcdn.com

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+util-inspect.js

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,1 @@
+node_modules

--- a/package.json
+++ b/package.json
@@ -2,6 +2,10 @@
   "name": "util-inspect",
   "version": "0.1.8",
   "description": "cross-browser node.js `util.inspect`",
+  "scripts": {
+    "build-umd": "browserify index.js -o util-inspect.js --standalone inspect",
+    "release": "npm run build-umd && npm publish"
+  },
   "dependencies": {
     "isarray": "0.0.1",
     "object-keys": "0.5.0",


### PR DESCRIPTION
This simply adds a UMD build so the lib can be used from places like JSBin, via npmcdn.com

I also added a `npm run release` script to enable running the build as part of the publish process. I did not use `prepublish` since it runs on `install` as well.
