### PR TITLE
Direct Node to built-in version

### DIFF
--- a/node.js
+++ b/node.js
@@ -1,0 +1,1 @@
+module.exports = require("util").inspect;

--- a/package.json
+++ b/package.json
@@ -2,6 +2,8 @@
   "name": "util-inspect",
   "version": "0.1.8",
   "description": "cross-browser node.js `util.inspect`",
+  "main": "node.js",
+  "browser": "index.js",
   "dependencies": {
     "isarray": "0.0.1",
     "object-keys": "0.5.0",


### PR DESCRIPTION
Node's built-in version is more up-to-date, and it can read things deeper.
